### PR TITLE
feature: added hot reloading for ignore file

### DIFF
--- a/projtree/watcher.py
+++ b/projtree/watcher.py
@@ -28,14 +28,20 @@ class _DebouncedHandler(FileSystemEventHandler):
         self._lock = threading.Lock()
         self._timer: threading.Timer | None = None
 
+
     def on_any_event(self, event) -> None:
         path = Path(event.src_path)
+
+        # Always react to .projtreeignore changes
+        if path.name == ".projtreeignore":
+            self._schedule_regeneration()
+            return
 
         # Ignore non-structural events
         if event.event_type == "modified":
             return
 
-        # Unified ignore logic
+        # Unified ignore logic (includes output file)
         if is_ignored(
             path,
             self.root_path,


### PR DESCRIPTION
This pull request updates the event handling logic in `projtree/watcher.py` to ensure that changes to the `.projtreeignore` file are always detected and trigger a regeneration, regardless of the event type. This makes the watcher more robust and responsive to ignore rule changes.

Event handling improvements:

* The `on_any_event` method now immediately triggers regeneration when the `.projtreeignore` file changes, ensuring that updates to ignore rules are always picked up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced detection of `.projtreeignore` file modifications to ensure the project tree regenerates promptly when ignore rules change.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->