### PR TITLE
feature: Add versioning to the package

### DIFF
--- a/projtree/__init__.py
+++ b/projtree/__init__.py
@@ -1,0 +1,6 @@
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("projtree")
+except PackageNotFoundError:
+    __version__ = "0.0.0-dev"

--- a/projtree/cli.py
+++ b/projtree/cli.py
@@ -14,10 +14,7 @@ DEFAULT_OUTPUT = "structure.md"
 def parse_ignore(value: str) -> set[str]:
     return {item.strip() for item in value.split(",") if item.strip()}
 
-
-@click.group()
-@click.version_option(__version__, "-v", "--version", prog_name="projtree", message="%(prog)s version %(version)s")
-def main(argv: list[str] | None = None) -> int:
+def argparse_main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         prog="projtree",
         description="Generate a deterministic Markdown project tree.",
@@ -89,6 +86,21 @@ def main(argv: list[str] | None = None) -> int:
 
     return 0
 
+@click.command(
+        context_settings={
+            "ignore_unknown_options": True,
+            "allow_extra_args": True,
+        }
+    )
+@click.version_option(
+        __version__,
+        "-v", "--version",
+        prog_name="projtree",
+        message="%(prog)s version %(version)s",
+)
+@click.pass_context
+def main(ctx):
+    return argparse_main(ctx.args)
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    raise SystemExit(argparse_main())

--- a/projtree/cli.py
+++ b/projtree/cli.py
@@ -1,6 +1,8 @@
 import argparse
 import sys
 from pathlib import Path
+from projtree import __version__
+import click
 
 from projtree.generator import generate_markdown_tree
 from projtree.ignore import DEFAULT_IGNORES, load_ignore_file
@@ -13,6 +15,8 @@ def parse_ignore(value: str) -> set[str]:
     return {item.strip() for item in value.split(",") if item.strip()}
 
 
+@click.group()
+@click.version_option(__version__, "-v", "--version", prog_name="projtree", message="%(prog)s version %(version)s")
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         prog="projtree",


### PR DESCRIPTION
This pull request introduces version management and begins integrating the `click` library for CLI functionality in the `projtree` package. The most important changes are grouped by theme below.

Versioning improvements:

* Added dynamic version retrieval using `importlib.metadata` in `projtree/__init__.py`, with a fallback to `"0.0.0-dev"` if the package is not installed.
* Imported `__version__` from `projtree` in `projtree/cli.py` for use in CLI version display.

CLI enhancements:

* Integrated `click` and added a `@click.version_option` decorator to the CLI entry point, enabling users to display the package version via CLI flags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI entry point that provides a standard version option and integrates with existing command-line behavior.

* **Chores**
  * Exposed a package-level version attribute with a safe fallback for development installations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->