### PR TITLE
Document exact-name ignore semantics for ignore options

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ See the [usage documentation](docs/usage.md) for the full command reference, opt
 * For normal runs, CLI `--ignore` arguments are merged with project and built-in ignores
 * In `--watch` mode, CLI `--ignore` values are also forwarded, so watching uses built-in defaults, `.projtreeignore`, and any CLI-supplied ignores
 * Ignore rules match **exact names anywhere in the tree** (e.g., `src` ignores any file/dir named `src` at any depth)
+* Ignore entries are treated as exact names, not paths. For example, `target` works, but `src/target` does not match nested paths
 * No globbing, wildcards, or pattern-based matching in v1
 * If the output file is under the project root, its file name is also added to the ignore set to prevent regeneration loops
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -78,14 +78,16 @@ projtree -o tree.md
 - `--ignore IGNORE` - Comma-separated list of file or directory names to ignore
 
 > [!NOTE]
-> Make sure the directories aren't marked with `/`
+> Ignore entries are exact names only. Path-like values such as `src/target` are treated as a literal name and will not match nested paths.
 
 ```bash
 # Incorrect usage
-projtree --ignore node_modules/, __pycache__/
+projtree --ignore node_modules/,__pycache__/
+projtree --ignore src/target
 
 # Correct Usage
 projtree --ignore node_modules,__pycache__
+projtree --ignore target
 ```
 
 > **Alternatively:** Add your files and directories to the custom `.projtreeignore` file
@@ -96,6 +98,7 @@ __pycache__
 .git
 projtree.egg-info
 .pytest_cache
+target
 ```
 
 - `--watch` - Watch filesystem and regenerate on structural changes

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -255,3 +255,30 @@ class TestWatchAndWatchOnlyInteraction:
             ])
             
             assert result == 0
+
+
+class TestIgnorePathLikeEntries:
+    """Tests documenting exact-name ignore semantics."""
+
+    def test_ignore_option_path_like_value_does_not_ignore_nested_entry(self, tmp_path: Path):
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "target").write_text("", encoding="utf-8")
+
+        output = tmp_path / "structure.md"
+        result = argparse_main([str(tmp_path), "-o", str(output), "--ignore", "src/target"])
+
+        assert result == 0
+        contents = output.read_text(encoding="utf-8")
+        assert "target" in contents
+
+    def test_projtreeignore_path_like_value_does_not_ignore_nested_entry(self, tmp_path: Path):
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "target").write_text("", encoding="utf-8")
+        (tmp_path / ".projtreeignore").write_text("src/target\n", encoding="utf-8")
+
+        output = tmp_path / "structure.md"
+        result = argparse_main([str(tmp_path), "-o", str(output)])
+
+        assert result == 0
+        contents = output.read_text(encoding="utf-8")
+        assert "target" in contents


### PR DESCRIPTION
This pull request clarifies and enforces the behavior of ignore rules in the CLI tool, ensuring that ignore entries are treated as exact names rather than paths. It updates the documentation to reflect this behavior and adds tests to verify that path-like ignore values do not match nested paths.

**Documentation updates:**

* Updated `README.md` and `docs/usage.md` to clarify that ignore entries are treated as exact names only, not as paths, and that path-like values (e.g., `src/target`) will not match nested entries. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R136) [[2]](diffhunk://#diff-72376d0b487d7231cf31959bf266f6aea098e899743bae02e36d176cef4db476L81-R90)
* Added examples in `docs/usage.md` to illustrate correct and incorrect usage of ignore entries, and included `target` in the sample ignore list. [[1]](diffhunk://#diff-72376d0b487d7231cf31959bf266f6aea098e899743bae02e36d176cef4db476L81-R90) [[2]](diffhunk://#diff-72376d0b487d7231cf31959bf266f6aea098e899743bae02e36d176cef4db476R101)

**Testing improvements:**

* Added new tests in `tests/test_cli.py` to verify that both the CLI `--ignore` option and `.projtreeignore` file do not ignore nested entries when given path-like values, documenting the exact-name semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified ignore entry matching behavior: entries are treated as exact literal names, and path-like values (e.g., `src/target`) do not match nested paths in the directory tree.

* **Tests**
  * Added tests to verify path-like ignore semantics behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nuxview/Project-Tree/pull/18?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->