### PR TITLE
Enable CI for trusted publishing to PyPI on main/master push

### DIFF
--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -97,7 +97,9 @@ jobs:
   publish-pypi:
     name: Publish to PyPI
     needs: [test-pypi-connection, check-version]
-    if: needs.check-version.outputs.version_changed == 'true'
+    if: >-
+      needs.check-version.outputs.version_changed == 'true' &&
+      (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
     runs-on: ubuntu-latest
     environment: production
     permissions:

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -4,14 +4,13 @@ permissions:
   contents: read
 
 on:
-  pull_request_target:
-    types:
-      - closed
+  push:
     branches:
       - main
       - master
     paths:
       - pyproject.toml
+  workflow_dispatch:
 
 jobs:
   test-pypi-connection:
@@ -43,23 +42,29 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha || github.event.pull_request.base.ref }}
           fetch-depth: 0
           persist-credentials: false
 
       - name: Detect Version Change
         id: check
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BASE_SHA: ${{ github.event.before }}
+          IS_MANUAL: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           python3 -c '
           import os, re, subprocess, sys
 
           base_sha = os.environ.get("BASE_SHA", "")
           base_text = ""
-          if base_sha:
+          if base_sha and not base_sha.startswith("0000000"):
               try:
                   base_text = subprocess.check_output(["git", "show", f"{base_sha}:pyproject.toml"], text=True)
+              except Exception:
+                  pass
+
+          if not base_text:
+              try:
+                  base_text = subprocess.check_output(["git", "show", "HEAD~1:pyproject.toml"], text=True)
               except Exception:
                   base_text = ""
 
@@ -74,7 +79,11 @@ jobs:
           head_version = parse_field(head_text, "version")
           pkg_name = parse_field(head_text, "name")
 
-          version_changed = "true" if (base_version != head_version and head_version) else "false"
+          is_manual = os.environ.get("IS_MANUAL", "false").lower() == "true"
+          if is_manual:
+              version_changed = "true" if head_version else "false"
+          else:
+              version_changed = "true" if (base_version != head_version and head_version) else "false"
 
           output_file = os.environ.get("GITHUB_OUTPUT")
           if output_file:
@@ -88,7 +97,7 @@ jobs:
   publish-pypi:
     name: Publish to PyPI
     needs: [test-pypi-connection, check-version]
-    if: github.event.pull_request.merged == true && needs.check-version.outputs.version_changed == 'true'
+    if: needs.check-version.outputs.version_changed == 'true'
     runs-on: ubuntu-latest
     environment: production
     permissions:
@@ -98,7 +107,6 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.base.ref }}
           persist-credentials: false
 
       - name: Check Version on PyPI


### PR DESCRIPTION
This pull request updates the publishing workflow in `.github/workflows/publishing.yml` to simplify and improve the automation process for publishing to PyPI. The main changes include switching from a pull request-based trigger to a push-based and manual trigger, updating how version changes are detected, and removing unnecessary conditions and parameters related to pull requests.

**Workflow trigger and logic changes:**

* The workflow is now triggered on `push` to `main` or `master` branches and by manual dispatch, instead of on pull request closure.
* The logic for detecting version changes in `pyproject.toml` is updated to work with push events and manual triggers, including improved handling of the base SHA and fallback logic if the base commit is not available. [[1]](diffhunk://#diff-60ae0e3ad4084f4b39a8659e9ee0c139ef43cfb21d7ffa25758615d246b1ff26L46-R67) [[2]](diffhunk://#diff-60ae0e3ad4084f4b39a8659e9ee0c139ef43cfb21d7ffa25758615d246b1ff26R82-R85)

**Job condition and configuration simplification:**

* The condition for running the publish job is simplified: it now only checks if the version changed, removing the requirement for a merged pull request.
* Removed references to pull request-specific variables in the `Checkout Code` steps, since the workflow no longer depends on pull request events. [[1]](diffhunk://#diff-60ae0e3ad4084f4b39a8659e9ee0c139ef43cfb21d7ffa25758615d246b1ff26L46-R67) [[2]](diffhunk://#diff-60ae0e3ad4084f4b39a8659e9ee0c139ef43cfb21d7ffa25758615d246b1ff26L101)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release publishing to run after changes are pushed to the main branches.
  * Added support for manually starting a publishing run.
  * Improved version detection for automated and manual publishing.
  * Limited automatic publishing to changes involving project metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->